### PR TITLE
Moved POM into a separate namespace

### DIFF
--- a/Region-Kit/Region-Kit/ExtraPOM/Vector2ArrayField.cs
+++ b/Region-Kit/Region-Kit/ExtraPOM/Vector2ArrayField.cs
@@ -5,7 +5,9 @@ using DevInterface;
 using RWCustom;
 using UnityEngine;
 
-public static partial class PlacedObjectsManager {
+namespace RegionKit.POM
+{
+    public static partial class PlacedObjectsManager {
     /// <summary>
     /// A <see cref="ManagedField"/> that stores an array of <see cref="Vector2"/>s
     /// </summary>
@@ -142,4 +144,5 @@ public static partial class PlacedObjectsManager {
             }
         }
     }
+}
 }

--- a/Region-Kit/Region-Kit/Machinery/MachineryMPO.cs
+++ b/Region-Kit/Region-Kit/Machinery/MachineryMPO.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 using RWCustom;
 using RegionKit.Utils;
 
-using static PlacedObjectsManager;
+using static RegionKit.POM.PlacedObjectsManager;
 
 namespace RegionKit.Machinery
 {

--- a/Region-Kit/Region-Kit/Machinery/MachineryStatic.cs
+++ b/Region-Kit/Region-Kit/Machinery/MachineryStatic.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Text;
 using MonoMod.RuntimeDetour;
 using RegionKit.Utils;
+using RegionKit.POM;
 
 namespace RegionKit.Machinery
 {

--- a/Region-Kit/Region-Kit/ManagedObjectExamples.cs
+++ b/Region-Kit/Region-Kit/ManagedObjectExamples.cs
@@ -4,7 +4,7 @@ using DevInterface;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using UnityEngine;
-using static PlacedObjectsManager;
+using static RegionKit.POM.PlacedObjectsManager;
 
 namespace RegionKit
 {

--- a/Region-Kit/Region-Kit/MiscPO/MiscPOStatic.cs
+++ b/Region-Kit/Region-Kit/MiscPO/MiscPOStatic.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using MonoMod.RuntimeDetour;
 using RegionKit.Utils;
+using RegionKit.POM;
 
 namespace RegionKit.MiscPO
 {

--- a/Region-Kit/Region-Kit/MiscPO/MiscPO_MPO.cs
+++ b/Region-Kit/Region-Kit/MiscPO/MiscPO_MPO.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using RWCustom;
 
-using static PlacedObjectsManager;
+using static RegionKit.POM.PlacedObjectsManager;
 
 namespace RegionKit.MiscPO
 {

--- a/Region-Kit/Region-Kit/Objects/ColouredLightSource.cs
+++ b/Region-Kit/Region-Kit/Objects/ColouredLightSource.cs
@@ -1,4 +1,6 @@
 ﻿using UnityEngine;
+using RegionKit.POM;
+using static RegionKit.POM.PlacedObjectsManager;
 
 namespace RegionKit.Objects {
     public class ColouredLightSource : UpdatableAndDeletable {

--- a/Region-Kit/Region-Kit/Objects/Drawable.cs
+++ b/Region-Kit/Region-Kit/Objects/Drawable.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using RWCustom;
 using UnityEngine;
+using RegionKit.POM;
 
 namespace RegionKit.Objects {
     public class Drawable : CosmeticSprite {

--- a/Region-Kit/Region-Kit/Particles/ParticleBehaviourProvider.cs
+++ b/Region-Kit/Region-Kit/Particles/ParticleBehaviourProvider.cs
@@ -5,7 +5,7 @@ using System.Text;
 using UnityEngine;
 using RegionKit.Utils;
 
-using static PlacedObjectsManager;
+using static RegionKit.POM.PlacedObjectsManager;
 
 namespace RegionKit.Particles
 {

--- a/Region-Kit/Region-Kit/Particles/ParticlesMPO.cs
+++ b/Region-Kit/Region-Kit/Particles/ParticlesMPO.cs
@@ -10,7 +10,7 @@ using RWCustom;
 using static RegionKit.Utils.RKUtils;
 using static UnityEngine.Mathf;
 using static RWCustom.Custom;
-using static PlacedObjectsManager;
+using static RegionKit.POM.PlacedObjectsManager;
 
 namespace RegionKit.Particles
 {

--- a/Region-Kit/Region-Kit/Particles/ParticlesStatic.cs
+++ b/Region-Kit/Region-Kit/Particles/ParticlesStatic.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Reflection;
 using System.Reflection.Emit;
+using RegionKit.POM;
 
 namespace RegionKit.Particles
 {

--- a/Region-Kit/Region-Kit/PlacedObjectsManager.cs
+++ b/Region-Kit/Region-Kit/PlacedObjectsManager.cs
@@ -22,8 +22,9 @@ using System.Reflection;
 [module: UnverifiableCode]
 [assembly: SecurityPermission(SecurityAction.RequestMinimum, SkipVerification = true)]
 
-
-public static partial class PlacedObjectsManager
+namespace RegionKit.POM
+{
+    public static partial class PlacedObjectsManager
 {
     #region HOOKS
     private static bool _hooked = false;
@@ -2256,3 +2257,5 @@ public static partial class PlacedObjectsManager
 
     #endregion CONTROLS
 }
+}
+


### PR DESCRIPTION
This is necessary to prevent a certain monomod bug. Relevant on beepinex and PL (not RWML, but that is not widespread yet). Deets: https://discord.com/channels/849500620132974643/849525819855863809/880923901339791372
WARNING: this will affect anyone who uses RK as a ref asm. Should make sure they are notified before pushing in an update.