### PR TITLE
DaddyCorruptionArenaFixHook

### DIFF
--- a/Region-Kit/Region-Kit/DaddyCorruptionArenaFixHK.cs
+++ b/Region-Kit/Region-Kit/DaddyCorruptionArenaFixHK.cs
@@ -1,0 +1,35 @@
+﻿/// <summary>
+/// From LB Gamer.
+/// </summary>
+
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace RegionKit
+{
+	public static class DaddyCorruptionArenaFixHK
+	{
+		public static void ApplyHK()
+		{
+            On.DaddyCorruption.ctor += DaddyCorruption_ctorHK;
+		}
+
+        private static void DaddyCorruption_ctorHK(On.DaddyCorruption.orig_ctor orig, DaddyCorruption self, Room room)
+		{
+			if (!room.game.IsStorySession)
+			{
+				self.places = new List<PlacedObject>();
+				self.climbTubes = new List<DaddyCorruption.ClimbableCorruptionTube>();
+				self.restrainedDaddies = new List<DaddyCorruption.DaddyRestraint>();
+				self.eatCreatures = new List<DaddyCorruption.EatenCreature>();
+				self.GWmode = false;
+				self.effectColor = new Color(0f, 0f, 1f);
+				self.eyeColor = self.effectColor;
+			}
+			else
+			{
+				orig(self, room);
+			}
+		}
+	}
+}

--- a/Region-Kit/Region-Kit/DaddyCorruptionArenaFixHK.cs
+++ b/Region-Kit/Region-Kit/DaddyCorruptionArenaFixHK.cs
@@ -16,7 +16,7 @@ namespace RegionKit
 
         private static void DaddyCorruption_ctorHK(On.DaddyCorruption.orig_ctor orig, DaddyCorruption self, Room room)
 		{
-			if (!room.game.IsStorySession)
+			if (room.game.IsArenaSession)
 			{
 				self.places = new List<PlacedObject>();
 				self.climbTubes = new List<DaddyCorruption.ClimbableCorruptionTube>();

--- a/Region-Kit/Region-Kit/RegionKit.csproj
+++ b/Region-Kit/Region-Kit/RegionKit.csproj
@@ -36,6 +36,7 @@
     <Compile Include="AridBarrens\SandPuffs.cs" />
     <Compile Include="AridBarrens\SandStorm.cs" />
     <Compile Include="ARKillRect.cs" />
+    <Compile Include="DaddyCorruptionArenaFixHK.cs" />
     <Compile Include="ExtraPOM\Vector2ArrayField.cs" />
     <Compile Include="Objects\Drawable.cs" />
     <Compile Include="SuperstructureFusesFix.cs" />

--- a/Region-Kit/Region-Kit/RegionKitMod.cs
+++ b/Region-Kit/Region-Kit/RegionKitMod.cs
@@ -27,6 +27,7 @@ namespace RegionKit {
             //VARIOUS PATCHES
             RoomLoader.Patch();
             SuperstructureFusesFix.Patch();
+            DaddyCorruptionArenaFixHK.ApplyHK();
             CustomArenaDivisions.Patch();
             EchoExtender.EchoExtender.ApplyHooks();
             NewObjects.Hook();


### PR DESCRIPTION
Has nothing to do with the old rainDB patch. Does pretty much the same thing as daddy corruption patch or DaddyCorruptionArenaFixHook (modding-general version).