### PR TITLE
ARKillRect fix

### DIFF
--- a/Region-Kit/Region-Kit/ARKillRect.cs
+++ b/Region-Kit/Region-Kit/ARKillRect.cs
@@ -35,8 +35,7 @@ namespace RegionKit
                 {
                     for (int k = 0; k < room.physicalObjects[i][j].bodyChunks.Length; k++)
                     {
-                        Vector2 v = room.physicalObjects[i][j].bodyChunks[k].pos;
-                        if (Custom.InsideRect(room.GetTilePosition(v), rect))
+                        if (Custom.InsideRect(room.GetTilePosition(room.physicalObjects[i][j].bodyChunks[k].pos), rect))
                         {
                             if (room.physicalObjects[i][j] is Creature)
                             {

--- a/Region-Kit/Region-Kit/ARKillRect.cs
+++ b/Region-Kit/Region-Kit/ARKillRect.cs
@@ -35,8 +35,7 @@ namespace RegionKit
                 {
                     for (int k = 0; k < room.physicalObjects[i][j].bodyChunks.Length; k++)
                     {
-                        Vector2 a = room.physicalObjects[i][j].bodyChunks[k].ContactPoint.ToVector2();
-                        Vector2 v = room.physicalObjects[i][j].bodyChunks[k].pos + a * (room.physicalObjects[i][j].bodyChunks[k].rad + 30f);
+                        Vector2 v = room.physicalObjects[i][j].bodyChunks[k].pos * (room.physicalObjects[i][j].bodyChunks[k].rad + 30f);
                         if (Custom.InsideRect(room.GetTilePosition(v), rect))
                         {
                             if (room.physicalObjects[i][j] is Creature)

--- a/Region-Kit/Region-Kit/ARKillRect.cs
+++ b/Region-Kit/Region-Kit/ARKillRect.cs
@@ -35,7 +35,7 @@ namespace RegionKit
                 {
                     for (int k = 0; k < room.physicalObjects[i][j].bodyChunks.Length; k++)
                     {
-                        Vector2 v = room.physicalObjects[i][j].bodyChunks[k].pos * (room.physicalObjects[i][j].bodyChunks[k].rad + 30f);
+                        Vector2 v = room.physicalObjects[i][j].bodyChunks[k].pos;
                         if (Custom.InsideRect(room.GetTilePosition(v), rect))
                         {
                             if (room.physicalObjects[i][j] is Creature)


### PR DESCRIPTION
ARKillrect has an issue with the collision which causes it to kill the player above the rectangle displayed by devtools if the player is on solid ground. This makes some rooms in Aether Ridge impassable. 

The issue is caused in Lines 38-40 of Region-Kit/ARKillRect.cs.
`Vector2 a = room.physicalObjects[i][j].bodyChunks[k].ContactPoint.ToVector2();`
`Vector2 v = room.physicalObjects[i][j].bodyChunks[k].pos + a * (room.physicalObjects[i][j].bodyChunks[k].rad + 30f);`
`if (Custom.InsideRect(room.GetTilePosition(v), rect))`

Variable `a` changes depending on whenever the object is touching solid ground. When there is ground beneath the object, `a` is (0, -1).
Variable `v` uses the direction of variable `a` to move the hitpoint of the object 30 pixels + the radius of the bodychunk in the direction of the ground, which result in the hitbox of an ARKillrect acting like it does in the following image, in addition to other unexpected behaviors (especially in tunnels).
![Screenshot 2022-06-05 201529](https://user-images.githubusercontent.com/70550216/172076897-d5677e87-fbf7-4df6-9846-45994597d8b4.png)

A potential fix to this issue would be to remove lines 38 and 39, and use the position of the bodychunk as the hitpoint the ARKillrect will use. (Although it may desirable to instead figure out how to use the edge of the bodychunk for ARKillRect collision, if the hitbox needs to be more unforgiving).